### PR TITLE
fix: support uv run as well

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,15 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+    - name: self test action
+      uses: ./
+  
+  # Simulate a venv with pre-commit already installed
+  main-uv:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
@@ -21,5 +30,22 @@ jobs:
       run: |
         uv venv
         uv pip install pre-commit
+    - name: self test action
+      uses: ./
+
+  # Simulate pre-commit not installed, install with uvx
+  main-uvx:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install uv with Python ${{ matrix.python-version }}
+      uses: astral-sh/setup-uv@v5
+      with:
+          python-version: ${{ matrix.python-version }}
+    - name: Install Python ${{ matrix.python-version }}
+      run: uv python install
     - name: self test action
       uses: ./

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,12 +3,19 @@ on:
   push:
     branches: [main, test-me-*]
 
+permissions:
+  contents: read
+
 jobs:
   main:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - uses: actions/setup-python@v5
+      with:
+        python-version: "3.13"
     - name: self test action
       uses: ./
 
@@ -20,10 +27,14 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Install uv with Python ${{ matrix.python-version }}
       uses: astral-sh/setup-uv@v5
       with:
           python-version: ${{ matrix.python-version }}
+          enable-cache: true
+          cache-dependency-glob: ".pre-commit-config.yaml"
     - name: Install Python ${{ matrix.python-version }}
       run: uv python install
     - name: Install pre-commit
@@ -41,10 +52,14 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Install uv with Python ${{ matrix.python-version }}
       uses: astral-sh/setup-uv@v5
       with:
           python-version: ${{ matrix.python-version }}
+          enable-cache: true
+          cache-dependency-glob: ".pre-commit-config.yaml"
     - name: Install Python ${{ matrix.python-version }}
       run: uv python install
     - name: self test action

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/setup-python@v5
     - name: self test action
       uses: ./
-  
+
   # Simulate a venv with pre-commit already installed
   main-uv:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,5 +17,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
     - name: Install Python ${{ matrix.python-version }}
       run: uv python install
+    - name: Install pre-commit
+      run: |
+        uv venv
+        uv pip install pre-commit
     - name: self test action
       uses: ./

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ This does a few things:
 - installs `uv`
 - sets up the `pre-commit` cache
 
+By default, `pre-commit` is installed and invoked with `uvx`.
+If it detects that `pre-commit` is already installed (for example, in a venv), `uv run` is used instead.
+
 ### using this action with custom invocations
 
 By default, this action runs all the hooks against all the files.  `extra_args`

--- a/action.yml
+++ b/action.yml
@@ -8,9 +8,12 @@ inputs:
 runs:
   using: composite
   steps:
+  - run: echo "pythonLocation=$(which python)" >> "$GITHUB_ENV"
   - uses: actions/cache@v4
     with:
       path: ~/.cache/pre-commit
       key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
-  - run: uvx pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
+  - run: |
+    which pre-commit
+    uv run pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
     shell: bash

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,7 @@ runs:
   using: composite
   steps:
   - run: echo "pythonLocation=$(which python)" >> "$GITHUB_ENV"
+    shell: bash
   - uses: actions/cache@v4
     with:
       path: ~/.cache/pre-commit

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,6 @@ runs:
       path: ~/.cache/pre-commit
       key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
   - run: |
-      which pre-commit
+      which pre-commit || true
       uv run pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
     shell: bash

--- a/action.yml
+++ b/action.yml
@@ -8,12 +8,12 @@ inputs:
 runs:
   using: composite
   steps:
-  - run: echo "pythonLocation=$(which python)" >> "$GITHUB_ENV"
+  - run: echo "pythonVersion=$(python -c 'import platform; print(platform.python_version());')" >> "$GITHUB_ENV"
     shell: bash
   - uses: actions/cache@v4
     with:
       path: ~/.cache/pre-commit
-      key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      key: pre-commit-3|${{ env.pythonVersion }}|${{ hashFiles('.pre-commit-config.yaml') }}
   - run: |
       UV_PREFIX=
       if command -v uv; then
@@ -29,5 +29,6 @@ runs:
         echo "uv not installed, using pip"
         pip install pre-commit
       fi
+      echo $UV_PREFIX
       $UV_PREFIX pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
     shell: bash

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,6 @@ runs:
       path: ~/.cache/pre-commit
       key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
   - run: |
-      which pre-commit || true
+      which pre-commit || uv tool install pre-commit
       uv run pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
     shell: bash

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,6 @@ runs:
       path: ~/.cache/pre-commit
       key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
   - run: |
-    which pre-commit
-    uv run pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
+      which pre-commit
+      uv run pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
     shell: bash

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,16 @@ runs:
       path: ~/.cache/pre-commit
       key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
   - run: |
+      UV_PREFIX=
+      if [[ command -v uv ]]; then
+        if [[ command -v pre-commit ]]; then
+          UV_PREFIX="uv run"
+        else
+          UV_PREFIX="uvx"
+        fi
+      else
+        pip install pre-commit
+      fi
       which pre-commit || uv tool install pre-commit
-      uv run pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
+      $UV_PREFIX pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
     shell: bash

--- a/action.yml
+++ b/action.yml
@@ -16,15 +16,18 @@ runs:
       key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
   - run: |
       UV_PREFIX=
-      if [[ command -v uv ]]; then
-        if [[ command -v pre-commit ]]; then
+      if command -v uv; then
+        echo "uv is installed"
+        if command -v pre-commit; then
+          echo "pre-commit installed"
           UV_PREFIX="uv run"
         else
+          echo "pre-commit not installed"
           UV_PREFIX="uvx"
         fi
       else
+        echo "uv not installed, using pip"
         pip install pre-commit
       fi
-      which pre-commit || uv tool install pre-commit
       $UV_PREFIX pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
     shell: bash

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,6 @@ runs:
         echo "uv not installed, using pip"
         pip install pre-commit
       fi
-      echo $UV_PREFIX
+      echo "Running pre-commit with: ${UV_PREFIX} pre-commit"
       $UV_PREFIX pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
     shell: bash


### PR DESCRIPTION
Support several scenarios:

* the old way of installing `pre-commit` via `pip install`
* `uv run` when `uv` and `pre-commit` are already installed
* `uvx` when `uv` is installed but `pre-commit` is not