### PR TITLE
fix: use uv run properly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: "3.13"
+    - run: echo ${{ env.pythonLocation }}
     - name: self test action
       uses: ./
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,6 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: "3.13"
-    - run: echo ${{ env.pythonLocation }}
     - name: self test action
       uses: ./
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,8 @@ jobs:
       run: uv python install
     - name: Install pre-commit
       run: |
-        uv venv
-        uv pip install pre-commit
+        uv init
+        uv add pre-commit
     - name: self test action
       uses: ./
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ This does a few things:
 - sets up the `pre-commit` cache
 
 By default, `pre-commit` is installed and invoked with `uvx`.
-If it detects that `pre-commit` is already installed (for example, in a venv), `uv run` is used instead.
+If it detects that `uv.lock` exists, `uv run --no-sync` is used instead.
+In that case, it is expected that you 
 
 ### using this action with custom invocations
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This does a few things:
 
 By default, `pre-commit` is installed and invoked with `uvx`.
 If it detects that `uv.lock` exists, `uv run --no-sync` is used instead.
-In that case, it is expected that you 
+In that case, it is expected that you ensure that `pre-commit` is installed in the virtual environment.
 
 ### using this action with custom invocations
 

--- a/action.yml
+++ b/action.yml
@@ -20,11 +20,11 @@ runs:
         echo "uv is installed"
         # attempt to activate virtual environment if it exists
         source .venv/bin/activate || true
-        if command -v pre-commit; then
-          echo "pre-commit installed"
-          UV_PREFIX="uv run"
+        if command -v uv.lock; then
+          echo "using uv run"
+          UV_PREFIX="uv run --no-sync"
         else
-          echo "pre-commit not installed"
+          echo "using uvx"
           UV_PREFIX="uvx"
         fi
       else

--- a/action.yml
+++ b/action.yml
@@ -9,13 +9,14 @@ runs:
   using: composite
   steps:
   - run: |
-      echo "pythonVersion=$(python -c 'import platform; print(platform.python_version());')" >> "$GITHUB_ENV" # zizmor: ignore[github-env]
-      echo "pythonMachine=$(python -c 'import platform; print(platform.machine());')" >> "$GITHUB_ENV" # zizmor: ignore[github-env]
+      echo "pythonVersion=$(python -c 'import platform; print(platform.python_version());')" >> "$GITHUB_OUTPUT"
+      echo "pythonMachine=$(python -c 'import platform; print(platform.machine());')" >> "$GITHUB_OUTPUT"
     shell: bash
+    id: prepare
   - uses: actions/cache@v4
     with:
       path: ~/.cache/pre-commit
-      key: pre-commit-3|${{ env.pythonVersion }}-${{ env.pythonMachine }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      key: pre-commit-3|${{ steps.prepare.outputs.pythonVersion }}-${{ steps.prepare.outputs.pythonMachine }}|${{ hashFiles('.pre-commit-config.yaml') }}
   - run: |
       UV_PREFIX=
       if command -v uv; then

--- a/action.yml
+++ b/action.yml
@@ -8,12 +8,14 @@ inputs:
 runs:
   using: composite
   steps:
-  - run: echo "pythonVersion=$(python -c 'import platform; print(platform.python_version());')" >> "$GITHUB_ENV" # zizmor: ignore[github-env]
+  - run: |
+      echo "pythonVersion=$(python -c 'import platform; print(platform.python_version());')" >> "$GITHUB_ENV" # zizmor: ignore[github-env]
+      echo "pythonMachine=$(python -c 'import platform; print(platform.machine());')" >> "$GITHUB_ENV" # zizmor: ignore[github-env]
     shell: bash
   - uses: actions/cache@v4
     with:
       path: ~/.cache/pre-commit
-      key: pre-commit-3|${{ env.pythonVersion }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      key: pre-commit-3|${{ env.pythonVersion }}-${{ env.pythonMachine }}|${{ hashFiles('.pre-commit-config.yaml') }}
   - run: |
       UV_PREFIX=
       if command -v uv; then


### PR DESCRIPTION
Use `uv run --no-sync` when `uv.lock` is detected instead of checking for `pre-commit` executable.